### PR TITLE
Programmatic 3D context camera rotation

### DIFF
--- a/orbviz/visualiser/assets/base_assets.py
+++ b/orbviz/visualiser/assets/base_assets.py
@@ -164,6 +164,9 @@ class AbstractSimpleAsset(ABC):
 				except NotImplementedError:
 					continue
 
+	def onManualCameraRotate(self) -> None:
+		pass
+
 	@abstractmethod
 	def _initData(self, *args, **kwargs) -> None:
 		'''Initialise data used for drawing this and any child assets
@@ -197,6 +200,13 @@ class AbstractSimpleAsset(ABC):
 			self.is_stale = True'''
 		self.data['curr_index'] = index
 		self.setStaleFlagRecursive()
+
+	def getScreenMouseOverInfo(self) -> dict[str,list]:
+		mo_info = {'screen_pos':[], 'world_pos':[], 'strings':[], 'objects':[]}
+		return mo_info
+
+	def mouseOver(self, index:int) -> None:
+		return
 
 	def _listVisuals(self) -> tuple[list, list]:
 		keys = list(self.visuals.keys())
@@ -403,6 +413,9 @@ class AbstractCompoundAsset(ABC):
 					opt['callback'](opt['value'])
 				except NotImplementedError:
 					continue
+
+	def onManualCameraRotate(self) -> None:
+		pass
 
 	@abstractmethod
 	def _initData(self, *args, **kwargs) -> None:
@@ -687,6 +700,9 @@ class AbstractAsset(ABC):
 					continue
 				except KeyError:
 					continue
+
+	def onManualCameraRotate(self) -> None:
+		pass
 
 	@abstractmethod
 	def _initData(self, *args, **kwargs):

--- a/orbviz/visualiser/assets/gizmo.py
+++ b/orbviz/visualiser/assets/gizmo.py
@@ -197,6 +197,9 @@ class ViewBoxGizmo(base_assets.AbstractSimpleAsset):
 		if event.button == 1 and event.is_dragging:
 			self.setViewBoxTransform()
 
+	def onManualCameraRotate(self) -> None:
+		self.setViewBoxTransform()
+
 	def onResize(self, event:QtGui.QResizeEvent) -> None:
 		self.setViewBoxTransform()
 

--- a/orbviz/visualiser/contexts/canvas_wrappers/history3d_cw.py
+++ b/orbviz/visualiser/contexts/canvas_wrappers/history3d_cw.py
@@ -76,6 +76,7 @@ class History3DCanvasWrapper(BaseCanvas):
 		self.assets['groundstations'] = groundstations.GroundStation3DAsset(v_parent=self.view_box.scene)
 
 		self.assets['ECI_gizmo'] = gizmo.ViewBoxGizmo(v_parent=self.view_box)
+		self.assets['ECI_gizmo'].makeActive()
 		self.setCameraZoom(5*c.R_EARTH)
 
 	def getActiveAssets(self) -> list[base_assets.AbstractAsset|base_assets.AbstractCompoundAsset|base_assets.AbstractSimpleAsset]:
@@ -161,11 +162,16 @@ class History3DCanvasWrapper(BaseCanvas):
 			if asset.isActive():
 				asset.updateIndex(index)
 
+	def onManualCameraRotate(self) -> None:
+		for asset in self.assets.values():
+			if asset.isActive():
+				asset.onManualCameraRotate()
+
 	def recomputeRedraw(self) -> None:
 		for asset in self.assets.values():
 			# if asset_name == 'sun':
 			# 	continue
-			if asset.isActive():
+			if asset.isActive() and isinstance(asset,base_assets.AbstractVispyAsset):
 				asset.recomputeRedraw()
 
 

--- a/orbviz/visualiser/contexts/history3d_context.py
+++ b/orbviz/visualiser/contexts/history3d_context.py
@@ -213,6 +213,7 @@ class History3DContext(base.BaseContext):
 
 			self.canvas_wrapper.view_box.camera.azimuth = start_azimuth - ii*azimuth_step_angle
 			self.canvas_wrapper.view_box.camera.elevation = start_elevation - ii*elevation_step_angle
+			self.canvas_wrapper.onManualCameraRotate()
 			self.controls.time_slider.setValue(ii)
 			app.process_events()
 


### PR DESCRIPTION
adding functionality to all base assets to recompute on programmatic camera adjustment. Particularly important for the view-box gizmo (previously modifications to the camera programmitically would leave it stationary, as the new transform was only calculated on a mouse drag). Call baseCanvas.onManualCameraRotate, this must then be propagated to all assets