### PR TITLE
pull gen sensor image metadata from data sources

### DIFF
--- a/orbviz/model/data_models/sensor_data.py
+++ b/orbviz/model/data_models/sensor_data.py
@@ -47,6 +47,18 @@ class SensorData:
 					self._sens_latlon_cache[sens_key] = {}
 					self._cached_timesteps[sens_key] = np.full((num_samples),False)
 
+
+	def generateMetadata(self, idx:int, suite_name:str, sens_name:str) -> dict:
+		sens_key = (suite_name, sens_name)
+		d = {
+				'fov':self._sc_config.getSensorSuites()[suite_name].getSensorConfig(sens_name)['fov'],
+				'lens_model':self._lens_model[sens_key],
+				'curr_dt':self._timestamps[idx],
+				'bf_quat':self._sc_config.getSensorSuites()[suite_name].getSensorBodyQuat(sens_name),
+				'eci_quat':self._parent_data_model.getSCAttitude(self._sc_config.id).getSensorAttitudeQuat(suite_name, sens_name, idx)
+		}
+		return d
+
 	def getTimestamps(self) -> np.ndarray[tuple[int], np.dtype[np.datetime64]]:
 		return self._timestamps
 

--- a/orbviz/model/data_models/spacecraft_data.py
+++ b/orbviz/model/data_models/spacecraft_data.py
@@ -27,6 +27,17 @@ class SpacecraftData:
 	def getTimestamps(self) -> np.ndarray[tuple[int], np.dtype[np.datetime64]]:
 		return self._timestamps
 
+	def generateMetadata(self, idx:int) -> dict:
+		d = {
+				'id': self._sc_id,
+				'name': self._sc_config.name,
+				'curr_dt': self._timestamps[idx],
+				'quat': self._parent_data_model.getSCAttitude(self._sc_id).getAttitudeQuat(idx),
+				'pos': self._parent_data_model.getOrbit(self._sc_id).pos[idx,:]
+		}
+
+		return d
+
 	def get2DData(self, timestep_idx:int):
 		cache_key = timestep_idx
 		if self._cached_timesteps[cache_key]:

--- a/orbviz/visualiser/contexts/canvas_wrappers/sensor_views_cw.py
+++ b/orbviz/visualiser/contexts/canvas_wrappers/sensor_views_cw.py
@@ -79,23 +79,25 @@ class SensorViewsCanvasWrapper(BaseCanvas):
 	def _getCurrentDisplayedSensor(self, view:int) -> sensors.SensorImageAsset | None:
 		return self.displayed_sensors[view]
 
-	def generateSensorFullRes(self, sc_id: int, sens_suite_key: str, sens_key: str) -> tuple[np.ndarray, np.ndarray, object, SensorImgMetadata]:
-		# TOOD: use sc_id to select which spacecraft asset to generate
-		sc_asset = self.assets['spacecraft']
+	def generateSensorFullRes(self, idx:int, sc_id: int, sens_suite_key: str, sens_key: str) -> tuple[np.ndarray, np.ndarray, object, SensorImgMetadata]:
 		sensor_asset = self.assets['spacecraft'].getSensorSuiteByKey(sens_suite_key).getSensorByKey(sens_key)
+		# TODO: sensor_asset.generateFullRes should not be done by the asset, move out to model rather than view.
 		img_data, mo_data, moConverterFunction = sensor_asset.generateFullRes()
-		img_metadata = SensorImgMetadata(spacecraft_id=sc_id,
-						spacecraft_name=self.assets['spacecraft'].data['name'],
+		sc_metadata = self.data_models['history'].getSCData(sc_id).generateMetadata(idx)
+		sens_metadata = self.data_models['history'].getSCSensorData(sc_id).generateMetadata(idx, sens_suite_key, sens_key)
+		# TODO: check curr_datetimes are the same in both sources of metadata
+		img_metadata = SensorImgMetadata(spacecraft_id=sc_metadata['id'],
+						spacecraft_name=sc_metadata['name'],
 						sensor_suite_name=sens_suite_key,
 						sensor_name=sens_key,
 						resolution=(img_data.shape[1], img_data.shape[0]),
-						fov=sensor_asset.data['fov'],
-						lens_model=sensor_asset.data['lens_model'].__name__,
-						current_time=sensor_asset.data['curr_datetime'],
-						sensor_body_frame_quaternion = sensor_asset.data['bf_quat'],
-						spacecraft_quaternion=sc_asset.data['curr_quat'].reshape(4,).tolist(),
-						spacecraft_eci_position=sc_asset.data['curr_pos'].reshape(3,).tolist(),
-						sensor_eci_quaternion=sensor_asset.data['curr_quat'].reshape(4,).tolist(),
+						fov=sens_metadata['fov'],
+						lens_model=sens_metadata['lens_model'],
+						current_time=sens_metadata['curr_dt'],
+						sensor_body_frame_quaternion = sens_metadata['bf_quat'],
+						spacecraft_quaternion=sc_metadata['quat'].reshape(4,).tolist(),
+						spacecraft_eci_position=sc_metadata['pos'].reshape(3,).tolist(),
+						sensor_eci_quaternion=sens_metadata['eci_quat'].reshape(4,).tolist(),
 						image_md5_hash=None)
 
 		return img_data, mo_data, moConverterFunction, img_metadata

--- a/orbviz/visualiser/contexts/sensor_views_context.py
+++ b/orbviz/visualiser/contexts/sensor_views_context.py
@@ -73,7 +73,7 @@ class SensorViewsContext(BaseContext):
 	def connectControls(self) -> None:
 		self.controls.time_slider.add_connect(self._updateDisplayedIndex)
 		self.controls.sensor_view_selectors.selected.connect(self.setViewActiveSensor)
-		self.controls.sensor_view_selectors.generate.connect(self.generateSensorFullRes)
+		self.controls.sensor_view_selectors.generate.connect(self.generateSensorFullResCurrIdx)
 		self.controls.action_dict['save-gif']['callback'] = self.setupGIFDialog
 		self.controls.action_dict['save-screenshot']['callback'] = self.setupScreenshot
 
@@ -117,9 +117,13 @@ class SensorViewsContext(BaseContext):
 	def setViewActiveSensor(self, view_id:int, sc_id:int, suite_key:str, sens_key:str) -> None:
 		self.canvas_wrapper.selectSensor(view_id, sc_id, suite_key, sens_key)
 
-	def generateSensorFullRes(self, view_id:int, sc_id:int, suite_key:str, sens_key:str) -> None:
-		logger.debug('Generating Full Res for view %s: %s - %s - %s', view_id, sc_id, suite_key, sens_key)
-		img_data, mo_data, moConverterFunction, img_metadata = self.canvas_wrapper.generateSensorFullRes(sc_id, suite_key, sens_key)
+	def generateSensorFullResCurrIdx(self, view_id:int, sc_id:int, suite_key:str, sens_key:str) -> None:
+		idx = self.getIndex()
+		self.generateSensorFullRes(idx, view_id, sc_id, suite_key, sens_key)
+
+	def generateSensorFullRes(self, idx:int, view_id:int, sc_id:int, suite_key:str, sens_key:str) -> None:
+		logger.info('Generating Full Res @ idx: %s for view %s: %s - %s - %s', idx, view_id, sc_id, suite_key, sens_key)
+		img_data, mo_data, moConverterFunction, img_metadata = self.canvas_wrapper.generateSensorFullRes(idx, sc_id, suite_key, sens_key)
 		dialogs.fullResSensorImageDialog(img_data, mo_data, moConverterFunction, img_metadata)
 
 	def getIndex(self) -> int|None:


### PR DESCRIPTION
relied on data field of the sensor asset had previously been removed when moving data generation out of the asset. -> Move all metadata generation out of the asset.
Instead rely on data sources.